### PR TITLE
Removes unused `HostName::getSwsHosts` method

### DIFF
--- a/src/HostName.php
+++ b/src/HostName.php
@@ -238,21 +238,4 @@ class HostName
             );
         }
     }
-
-    /**
-     * Returns a key/value array of host names for all SWS web services.
-     *
-     * They key is the identifier for each service as used within the PHP SDK
-     * See https://github.com/serato/sws-php-sdk#configuring-the-sdk for more.
-     *
-     * @return array<String>
-     */
-    public function getSwsHosts(): array
-    {
-        $data = [];
-        foreach (self::SWS_HOSTS as $app => $id) {
-            $data[$id] = $this->get($app);
-        }
-        return $data;
-    }
 }

--- a/tests/unit/HostNameTest.php
+++ b/tests/unit/HostNameTest.php
@@ -99,15 +99,4 @@ class HostNameTest extends TestCase
             ['test', 12, HostName::IDENTITY, 'https://test-12'],
         ];
     }
-
-    /**
-     * Smoke test the HostName::getSwsHosts method
-     *
-     * @return void
-     */
-    public function testGetSwsHostsSmokeTest(): void
-    {
-        $hosts = new HostName('dev', 1);
-        $this->assertTrue(count($hosts->getSwsHosts()) > 1);
-    }
 }


### PR DESCRIPTION
Having the method in this library is a poor separation of concerns. It's better re-implemented in the SWS PHP SDK