### PR TITLE
Revised hostnames for `dev 2` environment

### DIFF
--- a/src/HostName.php
+++ b/src/HostName.php
@@ -44,7 +44,7 @@ class HostName
             'staging' => 'https://serato.xyz',
             'preprod' => 'https://serato.biz',
             'dev' => 'http://192.168.4.2:8080',
-            'dev2' => 'http://localhost:8500',
+            'dev2' => 'http://serato-websites:8500', // DNS name (and port) for internal Docker `frontend` network
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '.serato.net'
         ],
         self::MANAGE_SERATO_COM => [
@@ -52,7 +52,7 @@ class HostName
             'staging' => 'https://manage.serato.xyz',
             'preprod' => 'https://manage.serato.biz',
             'dev' => 'http://192.168.4.2:8083',
-            'dev2' => 'http://localhost:8501',
+            'dev2' => 'http://serato-websites:8501', // DNS name (and port) for internal Docker `frontend` network
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-manage.serato.net'
         ],
         self::AUTH_SERATO_COM => [
@@ -60,7 +60,7 @@ class HostName
             'staging' => 'https://auth.serato.xyz',
             'preprod' => 'https://auth.serato.biz',
             'dev' => 'http://192.168.4.2:8081',
-            'dev2' => 'http://localhost:8502',
+            'dev2' => 'http://serato-websites:8502', // DNS name (and port) for internal Docker `frontend` network
             'test' => 'http://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-my.serato.net'
         ],
         self::STORE_SERATO_COM => [
@@ -76,7 +76,6 @@ class HostName
             # No DNS entry for this (ie. doesn't exist in pre-prod):
             'preprod' => 'https://api.serato.biz',
             'dev' => 'http://192.168.5.2',
-            'dev2' => 'http://localhost:8506',
             # No test stacks exist and no DNS entries. So this is made up :-)
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-api.serato.net'
         ],
@@ -85,7 +84,7 @@ class HostName
             'staging' => 'https://playlists.serato.xyz',
             'preprod' => 'https://playlists.serato.biz',
             'dev' => 'http://192.168.4.2:8085',
-            'dev2' => 'http://localhost:8503',
+            'dev2' => 'http://serato-websites:8503', // DNS name (and port) for internal Docker `frontend` network
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-playlists.serato.net'
         ],
         self::OLD_SCRATCHLIVE_NET => [
@@ -93,7 +92,7 @@ class HostName
             'staging' => 'https://translation.serato.xyz',
             'preprod' => 'https://translation.serato.biz',
             'dev' => 'http://192.168.4.2:8086',
-            'dev2' => 'http://localhost:8504',
+            'dev2' => 'http://serato-websites:8504', // DNS name (and port) for internal Docker `frontend` network
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-translation.serato.net'
         ],
         self::SERA_TO => [
@@ -101,7 +100,7 @@ class HostName
             'staging' => 'https://redirects.serato.xyz',
             'preprod' => 'http://redirects.serato.biz',
             'dev' => 'http://192.168.4.2:8084',
-            'dev2' => 'http://localhost:8505',
+            'dev2' => 'http://serato-websites:8505', // DNS name (and port) for internal Docker `frontend` network
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-redirects.serato.net'
         ],
         self::IN_SERA_TO_API => [
@@ -110,7 +109,6 @@ class HostName
             # No DNS entry for this (ie. doesn't exist in pre-prod):
             'preprod' => 'https://in-api.serato.xyz',
             'dev' => 'http://192.168.0.2',
-            'dev2' => 'http://localhost:8507',
             # No test stacks exist and no DNS entries. So this is made up :-)
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-in-api.serato.net'
         ],
@@ -176,7 +174,7 @@ class HostName
             'staging' => 'https://id.serato.xyz',
             'preprod' => 'https://id.serato.biz',
             'dev' => 'http://192.168.4.14:8585',
-            'dev2' => 'http://localhost:8300',
+            'dev2' => 'http://sws-identity', // DNS name for internal Docker `frontend` network (HTTP available on port 80)
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-id.serato.net',
             'sws_host_key' => 'id'
         ],
@@ -185,7 +183,7 @@ class HostName
             'staging' => 'https://license.serato.xyz',
             'preprod' => 'https://license.serato.biz',
             'dev' => 'http://192.168.4.14:8686',
-            'dev2' => 'http://localhost:8301',
+            'dev2' => 'http://sws-license', // DNS name for internal Docker `frontend` network (HTTP available on port 80)
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-license.serato.net',
             'sws_host_key' => 'license'
         ],
@@ -194,7 +192,7 @@ class HostName
             'staging' => 'https://ecom.serato.xyz',
             'preprod' => 'https://ecom.serato.biz',
             'dev' => 'http://192.168.4.14:8787',
-            'dev2' => 'http://localhost:8302',
+            'dev2' => 'http://sws-ecom', // DNS name for internal Docker `frontend` network (HTTP available on port 80)
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-ecom.serato.net',
             'sws_host_key' => 'ecom'
         ],
@@ -203,7 +201,7 @@ class HostName
             'staging' => 'https://notifications.serato.xyz',
             'preprod' => 'https://notifications.serato.biz',
             'dev' => 'http://192.168.4.14:8484',
-            'dev2' => 'http://localhost:8303',
+            'dev2' => 'http://sws-notifications', // DNS name for internal Docker `frontend` network (HTTP available on port 80)
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-notifications.serato.net',
             'sws_host_key' => 'notifications'
         ],
@@ -212,7 +210,7 @@ class HostName
             'staging' => 'https://da.serato.xyz',
             'preprod' => 'https://da.serato.biz',
             'dev' => 'http://192.168.4.14:8383',
-            'dev2' => 'http://localhost:8304',
+            'dev2' => 'http://sws-da', // DNS name for internal Docker `frontend` network (HTTP available on port 80)
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-da.serato.net',
             'sws_host_key' => 'da'
         ],
@@ -221,7 +219,7 @@ class HostName
             'staging' => 'https://profile.serato.xyz',
             'preprod' => 'https://profile.serato.biz',
             'dev' => 'http://192.168.4.14:8282',
-            'dev2' => 'http://localhost:8305',
+            'dev2' => 'http://sws-profile', // DNS name for internal Docker `frontend` network (HTTP available on port 80)
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-profile.serato.net',
             'sws_host_key' => 'profile'
         ],
@@ -230,7 +228,7 @@ class HostName
             'staging' => 'https://rewards.serato.xyz',
             'preprod' => 'https://rewards.serato.biz',
             'dev' => 'http://192.168.4.14:8788',
-            'dev2' => 'http://localhost:8306',
+            'dev2' => 'http://sws-rewards', // DNS name for internal Docker `frontend` network (HTTP available on port 80)
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-rewards.serato.net',
             'sws_host_key' => 'rewards'
         ],
@@ -239,7 +237,7 @@ class HostName
             'staging' => 'https://video.serato.xyz',
             'preprod' => 'https://video.serato.biz',
             'dev' => 'http://192.168.4.14:8789',
-            'dev2' => 'http://localhost:8307',
+            'dev2' => 'http://sws-video', // DNS name for internal Docker `frontend` network (HTTP available on port 80)
             'test' => 'https://test-' . self::TEST_STACK_NUM_PLACEHOLDER . '-video.serato.net',
             'sws_host_key' => 'video'
         ]


### PR DESCRIPTION
* Web apps now use internal Docker DNS names